### PR TITLE
Automatically run

### DIFF
--- a/Example.swift
+++ b/Example.swift
@@ -24,5 +24,3 @@ describe("a person") {
   }
 }
 
-run()
-

--- a/Spectre/GlobalContext.swift
+++ b/Spectre/GlobalContext.swift
@@ -23,7 +23,10 @@ class GlobalContext {
   }
 }
 
-let globalContext = GlobalContext()
+let globalContext: GlobalContext = {
+  atexit { run() }
+  return GlobalContext()
+}()
 
 public func describe(name:String, closure:ContextType -> ()) {
   globalContext.describe(name, closure: closure)


### PR DESCRIPTION
By adding an `atexit` hook when instantiating the global context, we can remove the need to call `run` manually.

There may be a better, more flexible solution to the problem, but I figured I'd throw the idea out there!