### PR TITLE
Updates for future versions of Swift

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-3.0-GM-CANDIDATE
+3.0.1

--- a/Sources/Expectation.swift
+++ b/Sources/Expectation.swift
@@ -57,7 +57,7 @@ public func expect<T>(_ file: String = #file, line: Int = #line, function: Strin
 public func == <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Equatable {
   if let value = try lhs.expression() {
     if value != rhs {
-      throw lhs.failure("\(value) is not equal to \(rhs)")
+      throw lhs.failure("\(String(describing: value)) is not equal to \(rhs)")
     }
   } else {
     throw lhs.failure("given value is nil")
@@ -67,7 +67,7 @@ public func == <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.Val
 public func != <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Equatable {
   let value = try lhs.expression()
   if value == rhs {
-    throw lhs.failure("\(value) is equal to \(rhs)")
+    throw lhs.failure("\(String(describing: value)) is equal to \(rhs)")
   }
 }
 
@@ -76,7 +76,7 @@ public func != <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.Val
 public func == <Element: Equatable> (lhs: Expectation<[Element]>, rhs: [Element]) throws {
   if let value = try lhs.expression() {
     if value != rhs {
-      throw lhs.failure("\(value) is not equal to \(rhs)")
+      throw lhs.failure("\(String(describing: value)) is not equal to \(rhs)")
     }
   } else {
     throw lhs.failure("given value is nil")
@@ -86,7 +86,7 @@ public func == <Element: Equatable> (lhs: Expectation<[Element]>, rhs: [Element]
 public func != <Element: Equatable> (lhs: Expectation<[Element]>, rhs: [Element]) throws {
   if let value = try lhs.expression() {
     if value == rhs {
-      throw lhs.failure("\(value) is equal to \(rhs)")
+      throw lhs.failure("\(String(describing: value)) is equal to \(rhs)")
     }
   } else {
     throw lhs.failure("given value is nil")
@@ -98,7 +98,7 @@ public func != <Element: Equatable> (lhs: Expectation<[Element]>, rhs: [Element]
 public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
   if let value = try lhs.expression() {
     if value != rhs {
-      throw lhs.failure("\(value) is not equal to \(rhs)")
+      throw lhs.failure("\(String(describing: value)) is not equal to \(rhs)")
     }
   } else {
     throw lhs.failure("given value is nil")
@@ -108,7 +108,7 @@ public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]
 public func != <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
   if let value = try lhs.expression() {
     if value == rhs {
-      throw lhs.failure("\(value) is equal to \(rhs)")
+      throw lhs.failure("\(String(describing: value)) is equal to \(rhs)")
     }
   } else {
     throw lhs.failure("given value is nil")
@@ -189,27 +189,27 @@ extension ExpectationType {
 public func > <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Comparable {
   let value = try lhs.expression()
   guard value! > rhs else {
-    throw lhs.failure("\(value) is not more than \(rhs)")
+    throw lhs.failure("\(String(describing: value)) is not more than \(rhs)")
   }
 }
 
 public func >= <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Comparable {
   let value = try lhs.expression()
   guard value! >= rhs else {
-    throw lhs.failure("\(value) is not more than or equal to \(rhs)")
+    throw lhs.failure("\(String(describing: value)) is not more than or equal to \(rhs)")
   }
 }
 
 public func < <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Comparable {
   let value = try lhs.expression()
   guard value! < rhs else {
-    throw lhs.failure("\(value) is not less than \(rhs)")
+    throw lhs.failure("\(String(describing: value)) is not less than \(rhs)")
   }
 }
 
 public func <= <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Comparable {
   let value = try lhs.expression()
   guard value! <= rhs else {
-    throw lhs.failure("\(value) is not less than or equal to \(rhs)")
+    throw lhs.failure("\(String(describing: value)) is not less than or equal to \(rhs)")
   }
 }


### PR DESCRIPTION
Few last Swift development snapshots are yapping about this:
```
./Spectre/Sources/Expectation.swift:70:25: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
    throw lhs.failure("\(value) is equal to \(rhs)")
                        ^~~~~~~
./Spectre/Sources/Expectation.swift:70:26: note: use 'String(describing:)' to silence this warning
    throw lhs.failure("\(value) is equal to \(rhs)")
                        ~^~~~~~
                         String(describing:  )
./Spectre/Sources/Expectation.swift:70:26: note: provide a default value to avoid this warning
    throw lhs.failure("\(value) is equal to \(rhs)")
                        ~^~~~~~
                               ?? <#default value#>
```
This PR makes Swift a good tail-waggling boy... :wink:
All builds and tests passed. 
```
Swift 3.0
[x] - Build
[x] - Test
Swift 3.0.1
[x] - Build
[x] - Test
Swift DEV SNAPSHOT 2016-11-11
[x] - Build
[x] - Test
```

@kylef Please review and merge. If you do, please bump the Spectre version tag as well. Thanks.