### PR TITLE
Adding support for type comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ try expect(5) < 10
 try expect(5) <= 10
 ```
 
+#### Types
+
+```swift
+try expect("kyle").to.beOfType(String.self)
+```
+
 #### Causing a failure
 
 ```swift

--- a/Sources/Expectation.swift
+++ b/Sources/Expectation.swift
@@ -144,6 +144,17 @@ extension ExpectationType where ValueType == Bool {
   }
 }
 
+// Mark: Types
+
+extension ExpectationType {
+  public func beOfType(_ type: Any.Type) throws {
+    guard let value = try expression() else { throw failure("cannot determine type: value is nil") }
+    if Mirror(reflecting: value).subjectType != type {
+      throw failure("value is not type of '\(type)'")
+    }
+  }
+}
+
 // MARK: Error Handling
 
 extension ExpectationType {

--- a/Sources/Expectation.swift
+++ b/Sources/Expectation.swift
@@ -147,10 +147,11 @@ extension ExpectationType where ValueType == Bool {
 // Mark: Types
 
 extension ExpectationType {
-  public func beOfType(_ type: Any.Type) throws {
-    guard let value = try expression() else { throw failure("cannot determine type: value is nil") }
-    if Mirror(reflecting: value).subjectType != type {
-      throw failure("value is not type of '\(type)'")
+  public func beOfType(_ expectedType: Any.Type) throws {
+    guard let value = try expression() else { throw failure("cannot determine type: expression threw an error or value is nil") }
+    let valueType = Mirror(reflecting: value).subjectType
+    if valueType != expectedType {
+      throw failure("'\(valueType)' is not the expected type '\(expectedType)'")
     }
   }
 }

--- a/Tests/SpectreTests/ExpectationSpec.swift
+++ b/Tests/SpectreTests/ExpectationSpec.swift
@@ -24,6 +24,33 @@ public func testExpectation() {
       try expect(name).to.beNil()
     }
   }
+  
+  $0.describe("comparison to type") {
+    class Animal {open func move() {}}
+    class Bear: Animal {func rawr() {}}
+    
+    $0.it("errors when value is not the same type") {
+      do {
+        try expect("kyle").to.beOfType(Bool.self)
+        fatalError()
+      } catch {}
+    }
+    
+    $0.it("passes when value is the same value type") {
+      try expect(true).to.beOfType(Bool.self)
+    }
+    
+    $0.it("passes when value is the same object type") {
+      try expect(Animal()).to.beOfType(Animal.self)
+    }
+    
+    $0.it("fails when value is a subclass of an object type") {
+      do {
+        try expect(Bear()).to.beOfType(Animal.self)
+        fatalError()
+      } catch {}
+    }
+  }
 
   $0.describe("equality extensions") {
     $0.describe("`==` operator") {


### PR DESCRIPTION
As described in #14, adding a method so we can now do something like:

```swift
try expect("kyle").to.beOfType(String.self)
```

Also updated the docs.

I did also attempt to support doing something like:

```swift
try expect(Mirror(reflecting: "kyle").subjectType)) == String.self
```

But I kept bumping up against the fact that `Any.Type` is a "*metatype*", which I don't really understand, but it means you can't, for instance, write a version of the equality operator like:

```swift
public func == <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Any.Type { ... }
```

Nor does something like the below work because `Any` is not `Equatable`:

```swift
public func == <E: ExpectationType>(lhs: E, rhs: E.ValueType) throws where E.ValueType: Any { ... }
```

Perhaps I'm coming at this the wrong way, but at least the `to.beOfType` use case is now supported!