### PR TITLE
Fix build errors when compiling with Xcode 9 GM

### DIFF
--- a/Sources/Expectation.swift
+++ b/Sources/Expectation.swift
@@ -95,7 +95,7 @@ public func != <Element: Equatable> (lhs: Expectation<[Element]>, rhs: [Element]
 
 // MARK: Dictionary Equatability
 
-public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
+public func == <Key, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
   if let value = try lhs.expression() {
     if value != rhs {
       throw lhs.failure("\(String(describing: value)) is not equal to \(rhs)")
@@ -105,7 +105,7 @@ public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]
   }
 }
 
-public func != <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
+public func != <Key, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
   if let value = try lhs.expression() {
     if value == rhs {
       throw lhs.failure("\(String(describing: value)) is equal to \(rhs)")


### PR DESCRIPTION
When building with Xcode 9 GM, we get the following errors:

```
[ehyche@GM19403 Spectre (ehyche_fix_swift4)]$ swift build
Compile Swift Module 'Spectre' (8 sources)
/Users/ehyche/src/personal/Spectre/Sources/Expectation.swift:98:22: warning: redundant conformance constraint 'Key': 'Equatable'
public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
                     ^
/Users/ehyche/src/personal/Spectre/Sources/Expectation.swift:98:57: note: conformance constraint 'Key': 'Equatable' inferred from type here
public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
                                                        ^
/Users/ehyche/src/personal/Spectre/Sources/Expectation.swift:108:22: warning: redundant conformance constraint 'Key': 'Equatable'
public func != <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
                     ^
/Users/ehyche/src/personal/Spectre/Sources/Expectation.swift:108:57: note: conformance constraint 'Key': 'Equatable' inferred from type here
public func != <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
                                                        ^
/Users/ehyche/src/personal/Spectre/Sources/Expectation.swift:98:22: warning: redundant conformance constraint 'Key': 'Equatable'
public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {
                     ^
/Users/ehyche/src/personal/Spectre/Sources/Expectation.swift:98:57: note: conformance constraint 'Key': 'Equatable' inferred from type here
public func == <Key: Equatable, Value: Equatable> (lhs: Expectation<[Key: Value]>, rhs: [Key: Value]) throws {

```

These changes fix those build errors. I also verified that it still builds against Swift 3.2 in Xcode 8.