### PR TITLE
Xcode reports

### DIFF
--- a/Sources/Spectre/Context.swift
+++ b/Sources/Spectre/Context.swift
@@ -34,6 +34,15 @@ class Context : ContextType, CaseType {
   var afters = [After]()
 
   init(name: String, disabled: Bool = false, parent: Context? = nil) {
+    var name = name
+    if name.hasPrefix("test") {
+      name = String(name.suffix(name.count - "test".count))
+      name = name.replacingOccurrences(of: "_", with: " ")
+    }
+    if name.hasSuffix("()") {
+      name = String(name.prefix(name.count - 2))
+    }
+
     self.name = name
     self.disabled = disabled
     self.parent = parent

--- a/Sources/Spectre/Context.swift
+++ b/Sources/Spectre/Context.swift
@@ -34,15 +34,6 @@ class Context : ContextType, CaseType {
   var afters = [After]()
 
   init(name: String, disabled: Bool = false, parent: Context? = nil) {
-    var name = name
-    if name.hasPrefix("test") {
-      name = String(name.suffix(name.count - "test".count))
-      name = name.replacingOccurrences(of: "_", with: " ")
-    }
-    if name.hasSuffix("()") {
-      name = String(name.prefix(name.count - 2))
-    }
-
     self.name = name
     self.disabled = disabled
     self.parent = parent

--- a/Sources/Spectre/Global.swift
+++ b/Sources/Spectre/Global.swift
@@ -28,6 +28,8 @@ public func run() -> Never  {
   } else {
     reporter = StandardReporter()
   }
+  
+  ANSI.isEnabled = !CommandLine.arguments.contains("--no-colors")
 
   run(reporter: reporter)
 }

--- a/Sources/Spectre/Global.swift
+++ b/Sources/Spectre/Global.swift
@@ -2,16 +2,62 @@
 import Glibc
 #else
 import Darwin
-#endif
+import XCTest
 
+extension XCTestCase {
+  
+  class Reporter: StandardReporter {
+    
+    weak var testCase: XCTestCase?
+    
+    override func printStatus() {
+      // while running with test case do not print status
+      // only print it in the very end
+      if testCase == nil {
+        super.printStatus()
+      }
+    }
+    
+    override func report(_ name: String, closure: (ContextReporter) -> Void) {
+      if depth == 0 {
+        print("")
+      }
+      super.report(name, closure: closure)
+    }
+    
+    override func addFailure(_ name: String, failure: FailureType) {
+      super.addFailure(name, failure: failure)
+      print("")
+
+      let name = (position + [name]).joined(separator: " ")
+      testCase?.recordFailure(withDescription: "\(name): \(failure.reason)", inFile: failure.file, atLine: failure.line, expected: false)
+    }
+    
+  }
+  
+  static let reporter = Reporter()
+  
+  public func describe(_ name: StaticString = #function, _ test: (ContextType) -> Void) {
+    XCTestCase.reporter.testCase = self
+    defer { XCTestCase.reporter.testCase = nil }
+    ANSI.isEnabled = !CommandLine.arguments.contains("--no-colors")
+
+    Spectre.describe(name, closure: test)
+    _ = globalContext.run(reporter: XCTestCase.reporter)
+    globalContext.cases.removeLast()
+  }
+  
+}
+
+#endif
 
 let globalContext: GlobalContext = {
   atexit { run() }
   return GlobalContext()
 }()
 
-public func describe(_ name: String, closure: (ContextType) -> Void) {
-  globalContext.describe(name, closure: closure)
+public func describe(_ name: StaticString = #function, closure: (ContextType) -> Void) {
+  globalContext.describe(String(describing: name), closure: closure)
 }
 
 public func it(_ name: String, closure: @escaping () throws -> Void) {
@@ -26,7 +72,11 @@ public func run() -> Never  {
   } else if CommandLine.arguments.contains("-t") {
     reporter = DotReporter()
   } else {
+    #if os(Linux)
     reporter = StandardReporter()
+    #else
+    reporter = XCTestCase.reporter
+    #endif
   }
   
   ANSI.isEnabled = !CommandLine.arguments.contains("--no-colors")

--- a/Sources/Spectre/Reporters.swift
+++ b/Sources/Spectre/Reporters.swift
@@ -14,8 +14,10 @@ enum ANSI : String, CustomStringConvertible {
   case Bold = "\u{001B}[0;1m"
   case Reset = "\u{001B}[0;0m"
 
+  static var isEnabled: Bool = true
+  
   var description:String {
-    if isatty(STDOUT_FILENO) > 0 {
+    if isatty(STDOUT_FILENO) > 0 && ANSI.isEnabled {
       return rawValue
     }
 

--- a/Tests/SpectreTests/FailureSpec.swift
+++ b/Tests/SpectreTests/FailureSpec.swift
@@ -15,6 +15,6 @@ public func testFailure() {
         // We cannot trust fail inside fails tests.
         fatalError("Test failed")
       }
-    }
+    }    
   }
 }

--- a/Tests/SpectreTests/XCTest.swift
+++ b/Tests/SpectreTests/XCTest.swift
@@ -1,8 +1,26 @@
 import XCTest
+import Spectre
 
 class SpectreTests: XCTestCase {
+  
   func testSpectre() {
     testFailure()
     testExpectation()
   }
+  
+  func test_Xcode_reporter() {
+    describe {
+      $0.it("reports failures") {
+        try expect(true) == false
+      }
+    }
+    
+    describe("Custom test") {
+      $0.it("reports failures") {
+        try expect(true) == false
+      }
+    }
+  }
+  
 }
+


### PR DESCRIPTION
Resolves #2 

This PR adds a very naive support for reporting test failures in Xcode. Instead of using runtime to create tests, as suggested in #17 I've added a method `XCTestCase.describe` that will store a reference to this test case in custom reporter, to use for reporting later, calls global describe function with passed in closure and then runs all the tests. At the end all added tests are removed so that they are not run again later. All individual test failures will appear in Issues navigator.

Tests will be still run at the application exit (without reporting via Xcode) but if they were already run with `XCTestCase.describe` they will be removed from the global context and so will not be run twice.

Also added option to disable colours in output which make output less readable in Xcode console, that does not support ANSI colors anyway.

![screen shot 2017-12-25 at 17 45 57](https://user-images.githubusercontent.com/1488293/34341625-945af98a-e99b-11e7-96c5-0ac89511f59b.png)
