### PR TITLE
More expectations

### DIFF
--- a/Sources/Spectre/Expectation.swift
+++ b/Sources/Spectre/Expectation.swift
@@ -184,6 +184,28 @@ extension ExpectationType {
     }
   }
 
+  public func toThrow(_ match: (Error) -> Bool) throws {
+    try `throw`(match)
+  }
+
+  public func `throw`(_ match: (Error) -> Bool) throws {
+    var thrownError: Error? = nil
+
+    do {
+      _ = try expression()
+    } catch {
+      thrownError = error
+    }
+
+    if let thrownError = thrownError {
+      if !match(thrownError) {
+        throw failure("\(thrownError) did not match")
+      }
+    } else {
+      throw failure("expression did not throw an error")
+    }
+  }
+
   public func toThrow<T: Equatable>(_ error: T) throws {
     try `throw`(error)
   }

--- a/Sources/Spectre/Expectation.swift
+++ b/Sources/Spectre/Expectation.swift
@@ -165,7 +165,12 @@ extension ExpectationType {
 // MARK: Error Handling
 
 extension ExpectationType {
+
   public func toThrow() throws {
+    try `throw`()
+  }
+
+  public func `throw`() throws {
     var didThrow = false
 
     do {
@@ -180,6 +185,10 @@ extension ExpectationType {
   }
 
   public func toThrow<T: Equatable>(_ error: T) throws {
+    try `throw`(error)
+  }
+
+  public func `throw`<T: Equatable>(_ error: T) throws {
     var thrownError: Error? = nil
 
     do {
@@ -200,6 +209,25 @@ extension ExpectationType {
       throw failure("expression did not throw an error")
     }
   }
+
+  public func notThrow() throws {
+    var didThrow = false
+    
+    do {
+      _ = try expression()
+    } catch {
+      didThrow = true
+    }
+    
+    if didThrow {
+      throw failure("expression did throw an error")
+    }
+  }
+  
+  public func toNotThrow() throws {
+    try notThrow()
+  }
+
 }
 
 // MARK: Comparable

--- a/Sources/Spectre/Expectation.swift
+++ b/Sources/Spectre/Expectation.swift
@@ -124,6 +124,12 @@ extension ExpectationType {
       throw failure("value is not nil")
     }
   }
+  public func beNotNil() throws {
+    let value = try expression()
+    if value == nil {
+      throw failure("value is nil")
+    }
+  }
 }
 
 // MARK: Boolean

--- a/Tests/SpectreTests/ExpectationSpec.swift
+++ b/Tests/SpectreTests/ExpectationSpec.swift
@@ -145,19 +145,28 @@ public func testExpectation() {
     func nonThrowing() throws {}
 
     $0.it("doesn't throw if error is the same") {
-      try expect(try throwing()).toThrow(FileError.notFound)
+      try expect(throwing()).to.throw(FileError.notFound)
     }
 
     $0.it("throws if the error differs") {
       do {
-        try expect(try throwing()).toThrow(FileError.noPermission)
+        try expect(throwing()).to.throw(FileError.noPermission)
         fatalError()
       } catch {}
     }
 
     $0.it("throws if no error was provided") {
       do {
-        try expect(try nonThrowing()).toThrow()
+        try expect(nonThrowing()).to.throw()
+        fatalError()
+      } catch {}
+    }
+    
+    $0.it("throws if error when no error expected") {
+      try expect(nonThrowing()).to.notThrow()
+      
+      do {
+        try expect(throwing()).to.notThrow()
         fatalError()
       } catch {}
     }

--- a/Tests/SpectreTests/ExpectationSpec.swift
+++ b/Tests/SpectreTests/ExpectationSpec.swift
@@ -23,6 +23,15 @@ public func testExpectation() {
     $0.it("passes when value is nil") {
       try expect(name).to.beNil()
     }
+    
+    $0.it("errors when value is nil") {
+      try expect("name").to.beNotNil()
+      
+      do {
+        try expect(name).to.beNotNil()
+        fatalError()
+      } catch {}
+    }
   }
   
   $0.describe("comparison to type") {

--- a/Tests/SpectreTests/ExpectationSpec.swift
+++ b/Tests/SpectreTests/ExpectationSpec.swift
@@ -137,6 +137,7 @@ public func testExpectation() {
       case notFound
       case noPermission
     }
+    enum AnotherError: Error {}
 
     func throwing() throws {
       throw FileError.notFound
@@ -151,6 +152,13 @@ public func testExpectation() {
     $0.it("throws if the error differs") {
       do {
         try expect(throwing()).to.throw(FileError.noPermission)
+        fatalError()
+      } catch {}
+    }
+
+    $0.it("throws if the error did not match") {
+      do {
+        try expect(throwing()).to.throw({ $0 is AnotherError })
         fatalError()
       } catch {}
     }

--- a/Tests/SpectreTests/ExpectationSpec.swift
+++ b/Tests/SpectreTests/ExpectationSpec.swift
@@ -25,10 +25,10 @@ public func testExpectation() {
     }
     
     $0.it("errors when value is nil") {
-      try expect("name").to.beNotNil()
+      try expect("name").to.not.beNil()
       
       do {
-        try expect(name).to.beNotNil()
+        try expect(name).to.not.beNil()
         fatalError()
       } catch {}
     }
@@ -171,10 +171,10 @@ public func testExpectation() {
     }
     
     $0.it("throws if error when no error expected") {
-      try expect(nonThrowing()).to.notThrow()
+      try expect(nonThrowing()).to.not.throw()
       
       do {
-        try expect(throwing()).to.notThrow()
+        try expect(throwing()).to.not.throw()
         fatalError()
       } catch {}
     }


### PR DESCRIPTION
- `beNotNil` to validate that value is not nil
- `notThrow` to validate that function does not throw
- `throw(_ match: (Error) -> Bool)` to validate that function throws error using custom condition rather than `Equatable`
- `throw` and `throw(_:)` expectations to better match other APIs (where `to` is omitted)
- `expect(...).to.not` for `not` expectations, `expect(...).to` has now better scoped methods and code completion