### PR TITLE
Report describe/it inside XCTestCases using XCTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Master
 
+### Breaking
+
+- Using Spectre in Xcode has be re-hauled, there are now `describe` and `it`
+  methods on `XCTestCase` which can be used. When used, these tests will be ran
+  directly and reported as XCTest failures and therefore shown in Xcode and
+  Xcode sidebar as XCTest failures.
+
+  Use of the global test context, i.e, global `describe` and `it` is no longer
+  permitted when using Spectre with XCTest.
+
 ### Enhancements
 
 - Unhandled errors will now be reported from the invoked cases source map.

--- a/Sources/Spectre/Global.swift
+++ b/Sources/Spectre/Global.swift
@@ -6,15 +6,20 @@ import Darwin
 
 
 let globalContext: GlobalContext = {
+#if os(macOS)
+  if getenv("XCTestConfigurationFilePath") != nil {
+    fatalError("Use of global context is not permitted when running inside XCTest")
+  }
+#endif
   atexit { run() }
   return GlobalContext()
 }()
 
-public func describe(_ name: String, closure: (ContextType) -> Void) {
+public func describe(_ name: String, _ closure: (ContextType) -> Void) {
   globalContext.describe(name, closure: closure)
 }
 
-public func it(_ name: String, closure: @escaping () throws -> Void) {
+public func it(_ name: String, _ closure: @escaping () throws -> Void) {
   globalContext.it(name, closure: closure)
 }
 

--- a/Sources/Spectre/XCTest.swift
+++ b/Sources/Spectre/XCTest.swift
@@ -1,0 +1,38 @@
+#if os(macOS)
+import XCTest
+
+
+extension XCTestCase {
+  public func describe(_ name: String, _ closure: (ContextType) -> Void) {
+    let context = Context(name: name)
+    closure(context)
+    context.run(reporter: XcodeReporter(testCase: self))
+  }
+
+  public func it(_ name: String, closure: @escaping () throws -> Void) {
+    let `case` = Case(name: name, closure: closure)
+    `case`.run(reporter: XcodeReporter(testCase: self))
+  }
+}
+
+
+class XcodeReporter: ContextReporter {
+  let testCase: XCTestCase
+
+  init(testCase: XCTestCase) {
+    self.testCase = testCase
+  }
+
+  func report(_ name: String, closure: (ContextReporter) -> Void) {
+    closure(self)
+  }
+
+  func addSuccess(_ name: String)  {}
+
+  func addDisabled(_ name: String) {}
+
+  func addFailure(_ name: String, failure: FailureType) {
+    testCase.recordFailure(withDescription: "\(name): \(failure.reason)", inFile: failure.file, atLine: failure.line, expected: false)
+  }
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,5 @@
+import Spectre
 import SpectreTests
 
-testExpectation()
-testFailure()
+describe("Expectation", testExpectation)
+describe("Failure", testFailure)

--- a/Tests/SpectreTests/ExpectationSpec.swift
+++ b/Tests/SpectreTests/ExpectationSpec.swift
@@ -1,8 +1,6 @@
 import Spectre
 
-
-public func testExpectation() {
-  describe("Expectation") {
+public let testExpectation: ((ContextType) -> Void) = {
   $0.it("can be created from a value") {
     let expectation = expect("value")
     let value = try expectation.expression()
@@ -191,5 +189,4 @@ public func testExpectation() {
       } catch {}
     }
   }
-}
 }

--- a/Tests/SpectreTests/FailureSpec.swift
+++ b/Tests/SpectreTests/FailureSpec.swift
@@ -1,20 +1,19 @@
 import Spectre
 
-public func testFailure() {
-  describe("Failure") {
-    $0.it("throws an error") {
-      var didFail = false
+public let testFailure: ((ContextType) -> Void) = {
+  $0.it("throws an error") {
 
-      do {
-        throw failure("it's broken")
-      } catch {
-        didFail = true
-      }
+    var didFail = false
 
-      if !didFail {
-        // We cannot trust fail inside fails tests.
-        fatalError("Test failed")
-      }
+    do {
+      throw failure("it's broken")
+    } catch {
+      didFail = true
+    }
+
+    if !didFail {
+      // We cannot trust fail inside fails tests.
+      fatalError("Test failed")
     }
   }
 }

--- a/Tests/SpectreTests/XCTest.swift
+++ b/Tests/SpectreTests/XCTest.swift
@@ -1,8 +1,9 @@
 import XCTest
+import Spectre
 
 class SpectreTests: XCTestCase {
   func testSpectre() {
-    testFailure()
-    testExpectation()
+    describe("Failure", testFailure)
+    describe("Expectation", testExpectation)
   }
 }


### PR DESCRIPTION
While reviewing #30, I had some alternative ideas that I wanted to test out. This is a simpler approach that adds a `describe` and `it` methods to `XCTestCase` via an extension, and immediately runs those closures and reports failures directly to XCTest.

This explicitly disallows use of the global context an thus if you try to use the global `describe` or `it` during an XCTest invocation a fatalError will be raised.

Example tests and report:

<img width="1072" alt="messages image 2733122485" src="https://user-images.githubusercontent.com/44164/34369529-3138ca9a-ea71-11e7-9c09-82717c99f817.png">

### Ideas for future extension

It would be nice to be able to inject the full test hierarchy into XCTest along with the skipped tests.

This will allow proper test reporting for `describe` and `context` inside Xcode output. Interacting with XCTest run-time is limited and I did not find a way to do this directly to XCTest.

I have in the past done this via injecting `NSInvocation`s to the test invocation list for a class, which would allow reporting each invocations separately. Unfortunately NSInvocation is not permitted in Swift (In Swift 2 I did find some measures to be able to do this (https://github.com/kylef/JSONSchema.swift/blob/0.2.0/JSONSchemaTests/JSONSchemaCases.swift#L63-L81) but that was broken in Swift 3).

This could be possible by including Objective-C sources, however that is problematic with Xcode projects generated with `swift package generate-xcodeproj`. You cannot link against the XCTest framework from Objective-C via swift pm (https://github.com/apple/swift-package-manager/pull/1422 would allow this in the future).

Closes #2