### PR TITLE
Add a `not` expectation property returning an opposite expectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Enhancements
 
 - Unhandled errors will now be reported from the invoked cases source map.
+- New `not` expectation method which returns a Not Expectation. This allows you
+  to run expecations such as:
+
+  ```swift
+  try expect(...).to.not.beNil()
+  ```
 
 ## 0.8.0
 

--- a/Tests/SpectreTests/ExpectationSpec.swift
+++ b/Tests/SpectreTests/ExpectationSpec.swift
@@ -23,6 +23,23 @@ public func testExpectation() {
     $0.it("passes when value is nil") {
       try expect(name).to.beNil()
     }
+
+    $0.context("not") {
+      $0.it("does not error when value is not nil") {
+        do {
+         try expect("kyle").to.not.beNil()
+        } catch {
+          fatalError()
+        }
+      }
+
+      $0.it("errors when value is nil") {
+        do {
+          try expect(name).to.not.beNil()
+          fatalError()
+        } catch {}
+      }
+    }
   }
   
   $0.describe("comparison to type") {


### PR DESCRIPTION
This allows you to run expectations such as:

```swift
try expect(...).to.not.beNil()
```