### PR TITLE
Update order of targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .library(name: "Spectre", targets: ["Spectre"]),
   ],
   targets: [
-    .target(name: "Spectre", dependencies: []),
     .testTarget(name: "SpectreTests", dependencies: ["Spectre"]),
+    .target(name: "Spectre", dependencies: []),
   ]
 )


### PR DESCRIPTION
When attempting to add [Stencil](https://github.com/kylef/Stencil) using [Marathon](https://github.com/johnsundell/Marathon) via a `Marathonfile`, I keep getting the following error which appears to be coming from here: 

```bash
 error: argument 'testDependencies' must precede argument 'dependencies'
```

In theory this shouldn't cause other issues, but my knowledge of SPM is not as strong as @kylef or @johnsundell, so I'd appreciate any feedback on why this change is a terrible idea.