### PR TITLE
Xcode12 support

### DIFF
--- a/Sources/Spectre/XCTest.swift
+++ b/Sources/Spectre/XCTest.swift
@@ -32,7 +32,11 @@ class XcodeReporter: ContextReporter {
   func addDisabled(_ name: String) {}
 
   func addFailure(_ name: String, failure: FailureType) {
-    testCase.recordFailure(withDescription: "\(name): \(failure.reason)", inFile: failure.file, atLine: failure.line, expected: false)
+    if #available(OSX 10.13, *) {
+        //This line should be replaced to XCTestCase.record(_:) on Xcode12+
+        //https://developer.apple.com/documentation/xctest/xctestcase/3546549-record
+        testCase.recordFailure(withDescription: "\(name): \(failure.reason)", inFile: failure.file, atLine: failure.line, expected: false)
+    }
   }
 }
 #endif


### PR DESCRIPTION
`XCTestCase.recordFailure(..)` method has been deprecated on Xcode12+ and it will cause compile error on Xcode12.

![スクリーンショット 2020-07-05 0 41 33](https://user-images.githubusercontent.com/46153/86516028-5d4dca00-be58-11ea-8269-54ee9e359976.png)

To avoid that, added `@available` block. 
In the future, `XCTestCase. recordFailure(..)` should be replaced with new API, `XCTestCase.record(_:)`.

Video
https://developer.apple.com/videos/play/wwdc2020/10687/
Document
https://developer.apple.com/documentation/xctest/xctestcase/3546549-record

