### PR TITLE
Add fix for Xcode 12.5

### DIFF
--- a/.github/workflows/xcode.yaml
+++ b/.github/workflows/xcode.yaml
@@ -6,7 +6,9 @@ jobs:
       DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode }}.app'
     strategy:
       matrix:
-        xcode: ['10.3', '11.3.1', '11.6', '12_beta']
+        # xcode 12.5 is not available yet, as it runs on macos-11 and macos 11 is in a private pool
+        # https://github.com/actions/virtual-environments/issues/2486
+        xcode: ['10.3', '11.3.1', '11.6', '12_beta', '12.4']
     steps:
       - uses: actions/checkout@v2
       - run: rm -fr IntegrationTests  # swift package will generate wrong package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support for Swift < 4.2 has been dropped.
 
+### Bug Fixes
+
+- Use `as` to cast `XCTIssueReference` to `XCTIssue` so it will compile on Xcode 12.5
+
 ### Enhancements
 
 - Reporter type can be set via an environment variable. For example, to use dot

--- a/Sources/Spectre/XCTest.swift
+++ b/Sources/Spectre/XCTest.swift
@@ -45,7 +45,11 @@ class XcodeReporter: ContextReporter {
     #else
     let issue = XCTIssue(type: .assertionFailure, compactDescription: "\(name): \(failure.reason)", detailedDescription: nil, sourceCodeContext: .init(location: location), associatedError: nil, attachments: [])
     #endif
+    #if compiler(>=5.4)
+    testCase.record(issue as XCTIssue)
+    #else
     testCase.record(issue)
+    #endif
     #else
     testCase.recordFailure(withDescription: "\(name): \(failure.reason)", inFile: failure.file, atLine: failure.line, expected: false)
     #endif


### PR DESCRIPTION
👋 

I was unable to compile this project using Xcode 12.5, and I didn't see any pull requests that fixed the problem so here's my attempt.

Steps to repro:

- Clone this repo
- Open Package.swift
- CMD+B

Compiler error on XCTest.swift:48 -

```
'XCTIssueReference' is not implicitly convertible to 'XCTIssue'; did you mean to use 'as' to explicitly convert?
```