### PR TITLE
Invalid exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Spectre Changelog
 
+## TBD
+
+### Bug fixes
+
+- Resolved error due to out of date `Package.swift` files.
+
+
 ## 0.10.0 (2021-05-15)
 
 ### Breaking Changes

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .library(name: "Spectre", targets: ["Spectre"]),
   ],
   targets: [
-    .target(name: "Spectre", exclude: ["XCTest@5.swift"]),
+    .target(name: "Spectre"),
     .testTarget(name: "SpectreTests", dependencies: ["Spectre"]),
   ]
 )

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -9,7 +9,7 @@ let package = Package(
     .library(name: "Spectre", targets: ["Spectre"]),
   ],
   targets: [
-    .target(name: "Spectre", exclude: ["Sources/Spectre/XCTest@5.swift"]),
+    .target(name: "Spectre"),
     .testTarget(name: "SpectreTests", dependencies: ["Spectre"]),
   ],
   swiftLanguageVersions: [.v4, .v4_2]

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -9,7 +9,7 @@ let package = Package(
     .library(name: "Spectre", targets: ["Spectre"]),
   ],
   targets: [
-    .target(name: "Spectre", exclude: ["XCTest@4.swift"]),
+    .target(name: "Spectre"),
     .testTarget(name: "SpectreTests", dependencies: ["Spectre"]),
   ],
   swiftLanguageVersions: [.v5]


### PR DESCRIPTION
It looks like in #44 (and release 0.9.2) the `XCTest@4.swift` and `XCTest@5.swift` files were removed, but the 3 `Package.swift` files were not updated to remove the excludes excluding them. This results in an error (presumably depending on what version of the tools since that will load different files) like #47.

This change removes the exclude from the Package.swift files since the excluded files no longer exist. I can confirm this works for me with the latest Xcode 13 beta.